### PR TITLE
feat: add Re-run button on job detail page

### DIFF
--- a/app.py
+++ b/app.py
@@ -505,6 +505,48 @@ def cancel_job(job_id):
     return jsonify({"ok": True, "status": "canceling"})
 
 
+@app.route("/rerun/<job_id>", methods=["POST"])
+def rerun_job(job_id):
+    """Create a new job using the same parameters as an existing job.
+
+    Useful for re-running a completed, failed, or canceled job without having
+    to navigate back to the home page and manually re-fill the form.
+    The original job is left untouched.
+    """
+    with jobs_lock:
+        source = jobs.get(job_id)
+    if not source:
+        abort(404)
+
+    params = dict(source["params"])
+    new_job_id = uuid4().hex[:8]
+    timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+    output_name = params.get("output_name", "web_run")
+    output_prefix = f"{output_name}_{timestamp}_{new_job_id}"
+
+    job_data = {
+        "id": new_job_id,
+        "status": "queued",
+        "params": params,
+        "output_prefix": output_prefix,
+        "created_at": datetime.utcnow().isoformat() + "Z",
+        "scrape_log": "",
+        "handle_log": "",
+        "certs": [],
+        "error": "",
+        "canceled": False,
+    }
+
+    with jobs_lock:
+        jobs[new_job_id] = job_data
+        _save_job(job_data)
+
+    thread = threading.Thread(target=_run_pipeline, args=(new_job_id,), daemon=True)
+    thread.start()
+
+    return redirect(url_for("job_page", job_id=new_job_id))
+
+
 @app.route("/delete/<job_id>", methods=["POST"])
 def delete_job(job_id):
     """Remove a job from memory, the database, and its CSV output files.

--- a/templates/job.html
+++ b/templates/job.html
@@ -28,6 +28,12 @@
       <p>
         <button id="cancel-btn" type="button">Cancel Job</button>
       </p>
+        <p>
+          <form id="rerun-form" method="post" action="/rerun/{{ job.id }}" style="display:inline">
+            <button type="submit" id="rerun-btn"
+              {% if job.status in ['queued', 'running'] %}disabled{% endif %}>Re-run Job</button>
+          </form>
+        </p>
       <p>
         <a href="/download/{{ job.id }}/allinfo">Download allinfo CSV</a> |
         <a href="/download/{{ job.id }}/data">Download data CSV</a> |
@@ -93,6 +99,7 @@
     const certsBody = document.getElementById("certs-body");
     const jobsBody = document.getElementById("jobs-body");
     const cancelBtn = document.getElementById("cancel-btn");
+  const rerunBtn = document.getElementById("rerun-btn");
 
     function toggleSection(id, btn) {
       const el = document.getElementById(id);
@@ -153,6 +160,13 @@
       if (data.status === "completed" || data.status === "failed" || data.status === "canceled") {
         cancelBtn.disabled = true;
       }
+
+        // Enable Re-run once the job has settled; disable it while still running.
+        if (data.status === "completed" || data.status === "failed" || data.status === "canceled") {
+          rerunBtn.disabled = false;
+        } else {
+          rerunBtn.disabled = true;
+        }
 
       if (data.status === "completed" || data.status === "failed" || data.status === "canceled") {
         return;


### PR DESCRIPTION
Adds a POST /rerun/<job_id> route that clones an existing job's parameters into a brand-new job and immediately starts the pipeline. The original job is left untouched.

- Re-run button is disabled while the job is queued/running and enabled once it is completed, failed, or canceled.
- Button state is kept in sync by the existing 2-second JS polling loop.